### PR TITLE
Fix several code quality issues identified in review

### DIFF
--- a/el/attributes.go
+++ b/el/attributes.go
@@ -2,6 +2,7 @@ package el
 
 import (
 	"html/template"
+	"sort"
 	"strings"
 )
 
@@ -17,11 +18,18 @@ type Attrs map[string]string
 func (a Attrs) render() string {
 	var w strings.Builder
 
-	for k, v := range a {
+	keys := make([]string, 0, len(a))
+	for k := range a {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
 		_, _ = w.WriteString(" ")
 		template.HTMLEscape(&w, []byte(k))
 		_, _ = w.WriteString(`="`)
-		template.HTMLEscape(&w, []byte(v))
+		template.HTMLEscape(&w, []byte(a[k]))
 		_, _ = w.WriteString(`"`)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/stanistan/veun
 
 go 1.21.4
 
+require github.com/alecthomas/assert/v2 v2.4.0
+
 require (
-	github.com/alecthomas/assert/v2 v2.4.0 // indirect
 	github.com/alecthomas/repr v0.3.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 )

--- a/internal/view/view.go
+++ b/internal/view/view.go
@@ -129,7 +129,7 @@ func V(in any) *View {
 	}
 }
 
-var errInvalidVParam = errors.New("can't consturct View")
+var errInvalidVParam = errors.New("can't construct View")
 
 // RenderError renders an error given an ErrorHandler.
 func RenderError(ctx context.Context, h ErrorHandler, err error) (template.HTML, error) {

--- a/template/template.go
+++ b/template/template.go
@@ -23,6 +23,12 @@ func MustParseFS(f fs.FS, ps ...string) *template.Template {
 	return template.Must(newTpl("ROOT").ParseFS(f, ps...))
 }
 
+// newTpl registers an empty slot func on the template so that
+// {{ slot "name" }} calls are valid at parse time. The context
+// passed here is intentionally context.TODO() because the slot
+// map is empty and the func will never be invoked during parsing;
+// the real per-request context is wired in via Slots.addToTemplate
+// at render time.
 func newTpl(name string) *template.Template {
 	return Slots{}.addToTemplate(context.TODO(), template.New(name))
 }

--- a/vhttp/handler.go
+++ b/vhttp/handler.go
@@ -72,9 +72,8 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		next.ServeHTTP(w, r)
 	}
 
-	_, err = w.Write([]byte(html))
-	if err != nil {
-		panic(err)
+	if _, err = w.Write([]byte(html)); err != nil {
+		slog.Error("veun write error", "err", err)
 	}
 }
 


### PR DESCRIPTION
- el/attributes.go: sort attribute keys before rendering to produce
  deterministic HTML output; the previous map iteration order caused
  a flaky test and unpredictable attribute ordering in general
- vhttp/handler.go: replace panic on ResponseWriter write error with
  slog.Error; client disconnects are not fatal and should not crash
  the goroutine
- internal/view/view.go: fix typo "consturct" -> "construct" in error
- template/template.go: add explanatory comment for context.TODO() in
  newTpl so future readers understand why it is safe here
- go.mod: run go mod tidy to mark alecthomas/assert as a direct dep

https://claude.ai/code/session_016ajAEaXWpQP2AfF7fx39ju